### PR TITLE
Ongoing enddate support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0-rc.3",
   "description": "An engine for drawing timeline graph.",
   "scripts": {
-    "lint": "eslint 'src/**/*.ts'",
-    "fix-lint": "eslint 'src/**/*.ts' --fix",
-    "docs": "typedoc './src/*.ts' --exclude **/node_modules/** --out docs/ --readme ./index.docs.md --tsconfig ./tsconfig.json --gitRemote upstream --name \"Short Night TypeScript Modules\" && nodetouch docs/.nojekyll",
+    "lint": "eslint \"src/**/*.ts\"",
+    "fix-lint": "eslint \"src/**/*.ts\" --fix",
+    "docs": "typedoc \"./src/*.ts\" --exclude \"**/node_modules/**\" --out docs/ --readme ./index.docs.md --tsconfig ./tsconfig.json --gitRemote upstream --name \"Short Night TypeScript Modules\" && nodetouch docs/.nojekyll",
     "watch-css": "node-sass src/styles.scss -o ./dist && node-sass src/styles.scss -wo ./dist",
     "watch-ts": "tsc --watch",
     "watch-pkg": "copy-and-watch --watch package.json ./dist",

--- a/src/Event/EventAxis.ts
+++ b/src/Event/EventAxis.ts
@@ -11,6 +11,7 @@ import EventMark from './EventMark';
  * @property {number} length - the length of EventAxis.
  * @property {number} offsetX - the offset X with Axis in EventAxis.
  * @property {[string]} text - the description about event ended.
+ * @property {[boolean]} ongoing - whether event is still ongoing or not
  * */
 interface DrawInfo extends ComponentDrawInfo {
     axisBodyDrawInfo :Readonly<AxisBody['drawInfo']>;
@@ -19,6 +20,7 @@ interface DrawInfo extends ComponentDrawInfo {
     length :number;
     offsetX :number;
     text ?:string;
+    ongoing ?:boolean;
 }
 
 /**

--- a/src/Event/index.ts
+++ b/src/Event/index.ts
@@ -21,6 +21,7 @@ import AxisBody from '../Axis/AxisBody';
  * @property {[number]} axisOffset - the offset X with Axis in EventAxis.
  * @property {[Date]} endDate - the date of event end.
  * @property {[string]} endText - the description about event ended.
+ * @property {[boolean]} ongoing - whether event is still ongoing or not
  * */
 interface DrawInfo extends ComponentDrawInfo {
     target :Coordinate;
@@ -40,6 +41,7 @@ interface DrawInfo extends ComponentDrawInfo {
 
     axisBodyDrawInfo :Readonly<AxisBody['drawInfo']>;
 
+    ongoing ?:boolean;
 }
 
 /**
@@ -174,12 +176,13 @@ export default abstract class Event extends Component {
 
         if (this.drawInfo.axisLength) {
             // @ts-ignore - realize a absolute class that will re-init in the theme.
-            const axis = this.axis || new this.axisConstructor(this);
+            const axis :EventAxis = this.axis || new this.axisConstructor(this);
             axis.drawInfo.axisBodyDrawInfo = this.drawInfo.axisBodyDrawInfo;
             axis.drawInfo.markDrawInfo = deepFreeze(this.mark.drawInfo);
             axis.drawInfo.offsetX = this.grid.minEventAxisOffset;
             axis.drawInfo.length = this.drawInfo.axisLength;
             axis.drawInfo.text = this.drawInfo.endText;
+            axis.drawInfo.ongoing = this.drawInfo.ongoing;
             this.axis = axis;
         }
     }

--- a/src/Timeline.ts
+++ b/src/Timeline.ts
@@ -23,9 +23,9 @@ import html2canvas from 'html2canvas';
  * @property {string} title - the title of event.
  *
  * @property {[string]} description - the description of event.
- * @property {[Date|'now']} endDate
+ * @property {[Date|'ongoing']} endDate
  * A date of event ended if event has.
- * Set "now" to specify the event is continuous.
+ * Set "ongoing" to specify the event is continuous.
  * @property {[string]} endText - the description of event ended if event has.
  *
  * @property {[boolean]} folded - the event is folded or not when timeline drawn.
@@ -40,7 +40,7 @@ interface DrawInfo extends ComponentDrawInfo {
         title :string,
 
         description ?:string,
-        endDate ?:string | 'now',
+        endDate ?:string | 'ongoing',
         endText ?:string,
 
         folded ?:boolean,
@@ -495,12 +495,13 @@ export default abstract class Timeline extends Component {
             event.drawInfo.endText = data.endText;
             if (data.endDate) {
                 const endDate :Date = parseDate(
-                    data.endDate === 'now'
+                    data.endDate === 'ongoing'
                         ? this.runtime.endDate
                         : data.endDate
                     ,
                 );
                 event.drawInfo.endDate = endDate.toISOString();
+                event.drawInfo.ongoing = data.endDate === 'ongoing';
                 event.drawInfo.axisLength = (endDate.getTime() - parseDate(data.date).getTime())
                     / dateLength
                     * this.axis.drawInfo.length;


### PR DESCRIPTION
Adds an 'ongoing' property to `EventAxis` `drawInfo`. This allows the timeline developer to style the axis based on whether the `endDate` is `ongoing` or just a string date.